### PR TITLE
Stop times after midnight fix

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -41,7 +41,16 @@ function formatStopTime(stoptime, options) {
     stoptime.classes.push('untimed');
     options.requestStopSymbolUsed = true;
   } else if (stoptime.departure_time) {
-    const time = moment(stoptime.departure_time, 'HH:mm:ss');
+    let timeStr = stoptime.departure_time,
+      hr = parseInt(timeStr.substr(0, timeStr.indexOf(':')), 10);
+    
+    // decrement time past 23 hours so moment can parse it
+    while(hr > 23) {
+      hr -= 24;
+    }
+
+    timeStr = hr + ':' + timeStr.substr(timeStr.indexOf(':'));
+    const time = moment(timeStr, 'HH:mm:ss');
     stoptime.formatted_time = time.format('h:mm');
     stoptime.formatted_period = time.format('A');
     stoptime.classes.push(time.format('a'));


### PR DESCRIPTION
Allow the output of stop times that occur after midnight by decrementing
the hour until it is parseable by moment.